### PR TITLE
[dev] make SegDataPreProcessor support 4D video

### DIFF
--- a/mmseg/models/data_preprocessor.py
+++ b/mmseg/models/data_preprocessor.py
@@ -55,16 +55,16 @@ class SegDataPreProcessor(BaseDataPreprocessor):
 
     def __init__(
         self,
-        mean: Sequence[Number] = None,
-        std: Sequence[Number] = None,
+        mean: Optional[Sequence[Number]] = None,
+        std: Optional[Sequence[Number]] = None,
         size: Optional[tuple] = None,
         size_divisor: Optional[int] = None,
-        pad_val: Number = 0,
-        seg_pad_val: Number = 255,
+        pad_val: float = 0,
+        seg_pad_val: float = 255,
         bgr_to_rgb: bool = False,
         rgb_to_bgr: bool = False,
         batch_augments: Optional[List[dict]] = None,
-        test_cfg: dict = None,
+        test_cfg: Optional[dict] = None,
     ):
         super().__init__()
         self.size = size
@@ -82,10 +82,8 @@ class SegDataPreProcessor(BaseDataPreprocessor):
                                     '`mean` and `std`.'
             # Enable the normalization in preprocessing.
             self._enable_normalize = True
-            self.register_buffer('mean',
-                                 torch.tensor(mean).view(-1, 1, 1), False)
-            self.register_buffer('std',
-                                 torch.tensor(std).view(-1, 1, 1), False)
+            self.register_buffer('mean', torch.tensor(mean), False)
+            self.register_buffer('std', torch.tensor(std), False)
         else:
             self._enable_normalize = False
 
@@ -109,13 +107,22 @@ class SegDataPreProcessor(BaseDataPreprocessor):
         data = self.cast_data(data)  # type: ignore
         inputs = data['inputs']
         data_samples = data.get('data_samples', None)
+        is_video = inputs[0].ndim == 4
         # TODO: whether normalize should be after stack_batch
-        if self.channel_conversion and inputs[0].size(0) == 3:
+        if is_video and self.channel_conversion and inputs[0].size(0) == 3:
+            inputs = [_input[:, [2, 1, 0], ...] for _input in inputs]
+        elif self.channel_conversion and inputs[0].size(0) == 3:
             inputs = [_input[[2, 1, 0], ...] for _input in inputs]
 
         inputs = [_input.float() for _input in inputs]
         if self._enable_normalize:
-            inputs = [(_input - self.mean) / self.std for _input in inputs]
+            if is_video:
+                mean = self.mean.view(1, -1, 1, 1)
+                std = self.std.view(1, -1, 1, 1)
+            else:
+                mean = self.mean.view(-1, 1, 1)
+                std = self.std.view(-1, 1, 1)
+            inputs = [(_input - mean) / std for _input in inputs]
 
         if training:
             assert data_samples is not None, ('During training, ',

--- a/mmseg/utils/misc.py
+++ b/mmseg/utils/misc.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -32,13 +32,14 @@ def stack_batch(inputs: List[torch.Tensor],
                 size: Optional[tuple] = None,
                 size_divisor: Optional[int] = None,
                 pad_val: Union[int, float] = 0,
-                seg_pad_val: Union[int, float] = 255) -> torch.Tensor:
+                seg_pad_val: Union[int, float] = 255
+                ) -> Tuple[torch.Tensor, SampleList]:
     """Stack multiple inputs to form a batch and pad the images and gt_sem_segs
     to the max shape use the right bottom padding mode.
 
     Args:
         inputs (List[Tensor]): The input multiple tensors. each is a
-            CHW 3D-tensor.
+            CHW 3D-tensor or TCHW 4D-tensor.
         data_samples (list[:obj:`SegDataSample`]): The list of data samples.
             It usually includes information such as `gt_sem_seg`.
         size (tuple, optional): Fixed padding size.
@@ -47,7 +48,7 @@ def stack_batch(inputs: List[torch.Tensor],
         seg_pad_val (int, float): The padding value. Defaults to 255
 
     Returns:
-       Tensor: The 4D-tensor.
+       Tensor: The 4D-tensor (images) or 5D-tensor (videos).
        List[:obj:`SegDataSample`]: After the padding of the gt_seg_map.
     """
     assert isinstance(inputs, list), \
@@ -55,11 +56,17 @@ def stack_batch(inputs: List[torch.Tensor],
     assert len({tensor.ndim for tensor in inputs}) == 1, \
         f'Expected the dimensions of all inputs must be the same, ' \
         f'but got {[tensor.ndim for tensor in inputs]}'
-    assert inputs[0].ndim == 3, f'Expected tensor dimension to be 3, ' \
+    assert inputs[0].ndim in (3, 4), \
+        f'Expected tensor dimension to be 3 or 4, ' \
         f'but got {inputs[0].ndim}'
     assert len({tensor.shape[0] for tensor in inputs}) == 1, \
         f'Expected the channels of all inputs must be the same, ' \
         f'but got {[tensor.shape[0] for tensor in inputs]}'
+    is_video = inputs[0].ndim == 4
+    if is_video:
+        assert len({tensor.shape[1] for tensor in inputs}) == 1, \
+            f'Expected the channels of all inputs must be the same, ' \
+            f'but got {[tensor.shape[1] for tensor in inputs]}'
 
     # only one of size and size_divisor should be valid
     assert (size is not None) ^ (size_divisor is not None), \
@@ -74,8 +81,7 @@ def stack_batch(inputs: List[torch.Tensor],
         max_size = (max_size +
                     (size_divisor - 1)) // size_divisor * size_divisor
 
-    for i in range(len(inputs)):
-        tensor = inputs[i]
+    for i, tensor in enumerate(inputs):
         if size is not None:
             width = max(size[-1] - tensor.shape[-1], 0)
             height = max(size[-2] - tensor.shape[-2], 0)

--- a/mmseg/version.py
+++ b/mmseg/version.py
@@ -1,6 +1,6 @@
 # Copyright (c) Open-MMLab. All rights reserved.
 
-__version__ = '1.2.3'
+__version__ = '1.2.4'
 
 
 def parse_version_info(version_str):


### PR DESCRIPTION
Normally `SegDataPreProcessor` only can take 3D tensors as image data. Now it supports to take 4D tensors as video data, the 4D tensor should have format (T, C, H, W)